### PR TITLE
fix: audacity and nmap package installation

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1,7 +1,7 @@
 ---
 argument_specs:
   main:
-    short_description: Main entry point for the init role
+    short_description: Install and configure a lot of packages to initialize a linux environment # yamllint disable-line rule:line-length
     description:
       - This is the main entrypoint for the init role.
       - There are only two dictionary lists available for this role init_users and init_groups

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -12,7 +12,6 @@
       register: apps_res
       ignore_errors: true
       loop:
-        - "which audacity"
         # - "chromium --version"
         - "clamscan --version"
         - "curl --version"

--- a/tasks/setup-suse.yml
+++ b/tasks/setup-suse.yml
@@ -21,3 +21,10 @@
     remote_src: true
     force: false
   when: _global_distribution_version == "tumbleweed"
+
+- name: Ensure openSUSE Factory network:utilities repo are enabled
+  community.general.zypper_repository:
+    repo: "https://download.opensuse.org/repositories/network:utilities/openSUSE_Factory/network:utilities.repo"
+    enabled: true
+    auto_import_keys: true
+  when: _global_distribution_version == "tumbleweed"

--- a/vars/family-debian.yml
+++ b/vars/family-debian.yml
@@ -6,7 +6,6 @@ _packages_ansible_bootstrap:
 
 _packages:
   - apt-transport-https
-  - audacity
   - build-essential
   - ca-certificates
   - clamav

--- a/vars/family-redhat.yml
+++ b/vars/family-redhat.yml
@@ -5,7 +5,6 @@ _packages_ansible_bootstrap:
   - sudo
 
 _packages:
-  - audacity
   - bind-utils
   - ca-certificates
   - chromium

--- a/vars/family-suse.yml
+++ b/vars/family-suse.yml
@@ -5,7 +5,6 @@ _packages_ansible_bootstrap:
   - sudo
 
 _packages:
-  - audacity
   - bind-utils
   - ca-certificates
   - chromium


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/Pandemonium1986/.github/blob/main/CONTRIBUTING.md#coding-conventions
-->

<!-- markdownlint-disable-next-line -->
#### Describe the change
Two major changes in this PR 
* `audacity` is no longer installed by default, as the tool is rarely used and is not present by default in SLES repos.
* `nmap` installation in tumbleweed seems to have to go through opensuse Factory now.
<!-- A clear and concise description of what the pull request is. -->

#### Testing
`DKR_IMAGE=tumbleweed molecule test`

<!-- In case a feature was added, how were tests performed? -->

#### Additional information

<!-- Add any other information -->
